### PR TITLE
🐛 Fix requires-python in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "yourpkg"
 description = ""
 readme = "README.md"
-requires-python = "3.10"
+requires-python = "~=3.10"
 license = "MIT"
 authors = [
   { name = "Shuhei Nitta", email = "huisintheta@gmail.com" }


### PR DESCRIPTION
## Description

`pip install .` fails with  `ValueError` of "Field `project.requires-python` is invalid: Invalid specifier: '3.10'".

## Reproducible Code

Run `pip install -e .`.

### Expected Behavior

The package is installed successfully.

### Actual Behavior

`pip` exits non-zero code because of `error: etadata-generation-failed`

Here is the actual output.

```console
Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///workspaces/noname
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [36 lines of output]
      Traceback (most recent call last):
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/packaging/specifiers.py", line 634, in __init__
          parsed.add(Specifier(specifier))
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/packaging/specifiers.py", line 98, in __init__
          raise InvalidSpecifier(f"Invalid specifier: '{spec}'")
      packaging.specifiers.InvalidSpecifier: Invalid specifier: '3.10'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/hatchling/metadata/core.py", line 552, in requires_python
          self._python_constraint = SpecifierSet(requires_python)
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/packaging/specifiers.py", line 636, in __init__
          parsed.add(LegacySpecifier(specifier))
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/packaging/specifiers.py", line 253, in __init__
          super().__init__(spec, prereleases)
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/packaging/specifiers.py", line 98, in __init__
          raise InvalidSpecifier(f"Invalid specifier: '{spec}'")
      packaging.specifiers.InvalidSpecifier: Invalid specifier: '3.10'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 191, in prepare_metadata_for_build_editable
          return hook(metadata_directory, config_settings)
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/hatchling/build.py", line 89, in prepare_metadata_for_build_editable
          f.write(builder.config.core_metadata_constructor(builder.metadata, extra_dependencies=extra_dependencies))
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/hatchling/metadata/spec.py", line 124, in construct_metadata_file_2_1
          if metadata.core.requires_python:
        File "/tmp/pip-build-env-x1gbjd_8/overlay/lib/python3.10/site-packages/hatchling/metadata/core.py", line 554, in requires_python
          raise ValueError(f'Field `project.requires-python` is invalid: {e}')
      ValueError: Field `project.requires-python` is invalid: Invalid specifier: '3.10'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
